### PR TITLE
Change ${user} to $(id -un)

### DIFF
--- a/pzserver/pzupdate
+++ b/pzserver/pzupdate
@@ -8,9 +8,9 @@ if [ -z "${RESTARTS}" ]; then
 	exit
 fi
 
-INDEX=$(jq -r -c "try .pzservers | index(\"${USER}\")" "${CONFIG}")
+INDEX=$(jq -r -c "try .pzservers | index(\"$(id -un)\")" "${CONFIG}")
 if [ "${INDEX}" = 'null' ]; then
-	echo No pzserver configured for user ${USER}
+	echo No pzserver configured for user $(id -un)
 	exit
 fi
 
@@ -23,7 +23,7 @@ for RESTART in ${RESTARTS[@]}; do
 	if [ "${RESTART}" = "${DATE}" ]; then
 
 		echo "${MSG}"                 >> "${LOCALLOG}"
-		pzrestartjob "${USER}" --stop >> "${LOCALLOG}"
+		pzrestartjob "$(id -un)" --stop >> "${LOCALLOG}"
 		echo pzrestartjob status: $?  >> "${LOCALLOG}"
 		pzinstall                     >> "${LOCALLOG}"
 		echo pzinstall status: $?     >> "${LOCALLOG}"


### PR DESCRIPTION
$(id -un) should be the way to go to get effective id of the user running the script.
${user} is subjective to how the system configured to deal with how the user login to the linux, like remote shell.