### PR TITLE
Servername is equal to username

### DIFF
--- a/pypzst/src/pypzst/__init__.py
+++ b/pypzst/src/pypzst/__init__.py
@@ -3,7 +3,6 @@
 import sys
 import logging
 import requests
-import subprocess
 
 import os
 from os.path import exists, isfile, join
@@ -108,10 +107,8 @@ def parse_server_config(server):
 
 	server_config = {}
 
-	localconfig = '$HOME/.pzst/config.json'
-	get_config = "jq -r 'try .servername' %s 2> /dev/null" % localconfig
-	servername = subprocess.run(['bash','-c',get_config])
-	server_ini = '/home/%s/Zomboid/Server/%s.ini' % (server, servername)
+
+	server_ini = '/home/%s/Zomboid/Server/%s.ini' % server
 	if not isfile(server_ini):
 		return server_config
 

--- a/pypzst/src/pypzst/__init__.py
+++ b/pypzst/src/pypzst/__init__.py
@@ -108,7 +108,7 @@ def parse_server_config(server):
 	server_config = {}
 
 
-	server_ini = '/home/%s/Zomboid/Server/%s.ini' % server
+	server_ini = '/home/%s/Zomboid/Server/%s.ini' % (server, server)
 	if not isfile(server_ini):
 		return server_config
 

--- a/pypzst/src/pypzst/__init__.py
+++ b/pypzst/src/pypzst/__init__.py
@@ -3,6 +3,7 @@
 import sys
 import logging
 import requests
+import subprocess
 
 import os
 from os.path import exists, isfile, join
@@ -107,7 +108,10 @@ def parse_server_config(server):
 
 	server_config = {}
 
-	server_ini = '/home/%s/Zomboid/Server/servertest.ini' % server
+	localconfig = '$HOME/.pzst/config.json'
+	get_config = "jq -r 'try .servername' %s 2> /dev/null" % localconfig
+	servername = subprocess.run(['bash','-c',get_config])
+	server_ini = '/home/%s/Zomboid/Server/%s.ini' % (server, servername)
 	if not isfile(server_ini):
 		return server_config
 

--- a/pzserver/pzenv
+++ b/pzserver/pzenv
@@ -45,19 +45,20 @@ STEAMCMD_URL="https://steamcdn-a.akamaihd.net/client/installer/${STEAMCMDARCHIVE
 
 ZOMBOIDGAMEID='108600'
 ZOMBOID="${HOME}/Zomboid"
+PZSERVERNAME="servertest"
 PZSERVER="${HOME}/pzserver"
-PZSERVERDB="${ZOMBOID}/db/servertest.db"
+PZSERVERDB="${ZOMBOID}/db/${PZSERVERNAME}.db"
 PZSERVERDIR="${ZOMBOID}/Server"
 PZSERVERLOG="${ZOMBOID}/server-console.txt"
 PZSERVERSAVE="${ZOMBOID}/Saves"
 PZSERVERBACKUP="${ZOMBOID}/Backups"
-PZSERVERCONFIG="${PZSERVERDIR}/servertest.ini"
+PZSERVERCONFIG="${PZSERVERDIR}/${PZSERVERNAME}.ini"
 PZSERVERMAPDIR="${PZSERVER}/media/maps"
 PZSERVERMODDIR="${PZSERVER}/steamapps/workshop/content/${ZOMBOIDGAMEID}"
 PZSERVERSTART="${PZSERVER}/start-server.sh"
-PZSERVERSANDBOX="${PZSERVERDIR}/servertest_SandboxVars.lua"
-PZSERVERSPAWNPOINTS="${PZSERVERDIR}/servertest_spawnpoints.lua"
-PZSERVERSPAWNREGIONS="${PZSERVERDIR}/servertest_spawnregions.lua"
+PZSERVERSANDBOX="${PZSERVERDIR}/${PZSERVERNAME}_SandboxVars.lua"
+PZSERVERSPAWNPOINTS="${PZSERVERDIR}/${PZSERVERNAME}_spawnpoints.lua"
+PZSERVERSPAWNREGIONS="${PZSERVERDIR}/${PZSERVERNAME}_spawnregions.lua"
 PZSERVERLOCK="${CACHEDIR}/pzserver.${USER}.lock"
 
 JAVAMODSVERSION=0.0.1
@@ -101,6 +102,10 @@ install_steamcmd() {
 		tar xf "${STEAMCMDARCHIVEPATH}" -C "${STEAM}"
 		rm -f "${STEAMCMDARCHIVEPATH}"
 	fi
+}
+
+read_servername() {
+	
 }
 
 read_adminuser() {
@@ -197,6 +202,7 @@ check_first_time() {
 
 	ADMINUSER="$(jq -r 'try .admin // "pzadmin"' "${LOCALCONFIG}" 2> /dev/null)"
 	ADMINUSEROPTION="-adminusername ${ADMINUSER}"
+	SERVERNAMEOPTION="-servername ${PZSERVERNAME}"
 }
 
 check_is_pzserver_user() {

--- a/pzserver/pzenv
+++ b/pzserver/pzenv
@@ -104,19 +104,6 @@ install_steamcmd() {
 	fi
 }
 
-#read_servername() {
-#	DEFAULT_SERVERNAME='servertest'
-#	echo Enter new server name \(default: ${DEFAULT_SERVERNAME}\)
-#	read -e SERVERNAME
-#
-#	if [ -z "${SERVERNAME}" ]; then
-#		SERVERNAME="${DEFAULT_SERVERNAME}"
-#	fi
-#
-#	PZSERVERNAME="${SERVERNAME}"
-#	pzst_config --servername "${SERVERNAME}"
-#}
-
 read_adminuser() {
 
 	DEFAULT_ADMINUSER='pzadmin'
@@ -199,13 +186,6 @@ check_admin_exists() {
 }
 
 check_first_time() {
-
-	#SERVERNAME="$(jq -r 'try .servername' "${LOCALCONFIG}" 2> /dev/null)"
-	#if [ -z "${SERVERNAME}" ]; then
-	#	read_servername
-	#fi
-
-	#PZSERVERNAME="${SERVERNAME}"
 
 	if [ -z "$(check_admin_exists)" ]; then
 

--- a/pzserver/pzenv
+++ b/pzserver/pzenv
@@ -45,7 +45,7 @@ STEAMCMD_URL="https://steamcdn-a.akamaihd.net/client/installer/${STEAMCMDARCHIVE
 
 ZOMBOIDGAMEID='108600'
 ZOMBOID="${HOME}/Zomboid"
-PZSERVERNAME="servertest"
+PZSERVERNAME="${USER}"
 PZSERVER="${HOME}/pzserver"
 PZSERVERDB="${ZOMBOID}/db/${PZSERVERNAME}.db"
 PZSERVERDIR="${ZOMBOID}/Server"
@@ -104,9 +104,18 @@ install_steamcmd() {
 	fi
 }
 
-read_servername() {
-	
-}
+#read_servername() {
+#	DEFAULT_SERVERNAME='servertest'
+#	echo Enter new server name \(default: ${DEFAULT_SERVERNAME}\)
+#	read -e SERVERNAME
+#
+#	if [ -z "${SERVERNAME}" ]; then
+#		SERVERNAME="${DEFAULT_SERVERNAME}"
+#	fi
+#
+#	PZSERVERNAME="${SERVERNAME}"
+#	pzst_config --servername "${SERVERNAME}"
+#}
 
 read_adminuser() {
 
@@ -190,6 +199,13 @@ check_admin_exists() {
 }
 
 check_first_time() {
+
+	#SERVERNAME="$(jq -r 'try .servername' "${LOCALCONFIG}" 2> /dev/null)"
+	#if [ -z "${SERVERNAME}" ]; then
+	#	read_servername
+	#fi
+
+	#PZSERVERNAME="${SERVERNAME}"
 
 	if [ -z "$(check_admin_exists)" ]; then
 

--- a/pzserver/pzst_config
+++ b/pzserver/pzst_config
@@ -6,7 +6,7 @@ TMP=$(mktemp)
 
 usage() {
 	rm -f "${TMP}"
-	echo "Usage ${0} [--add|--del|--admin <username>|--install <path>|--port <port>]"
+	echo "Usage ${0} [--add|--del|--admin <username>|--servername <name>|--install <path>|--port <port>]"
 	exit
 }
 
@@ -41,6 +41,17 @@ elif [ "${ARG}" = '-A' ] || [ "${ARG}" = '--admin' ]; then
 	fi
 
 	jq --tab ".admin=\"${USERNAME}\"" "${LOCALCONFIG}" > "${TMP}"
+	cp "${TMP}" "${LOCALCONFIG}"
+elif [ "${ARG}" = '-s' ] || [ "${ARG}" = '--servername' ]; then
+
+	SERVERNAME="${2}"
+	if [-z "${SERVERNAME}" ]; then
+		echo Option \`${ARG}\` requires a name
+		echo
+		usage
+	fi
+
+	jq --tab ".servername=\"${SERVERNAME}\"" "${LOCALCONFIG}" > "${TMP}"
 	cp "${TMP}" "${LOCALCONFIG}"
 
 elif [ "${ARG}" = '-i' ] || [ "${ARG}" = '--install' ]; then

--- a/pzserver/pzst_config
+++ b/pzserver/pzst_config
@@ -42,17 +42,6 @@ elif [ "${ARG}" = '-A' ] || [ "${ARG}" = '--admin' ]; then
 
 	jq --tab ".admin=\"${USERNAME}\"" "${LOCALCONFIG}" > "${TMP}"
 	cp "${TMP}" "${LOCALCONFIG}"
-elif [ "${ARG}" = '-s' ] || [ "${ARG}" = '--servername' ]; then
-
-	SERVERNAME="${2}"
-	if [-z "${SERVERNAME}" ]; then
-		echo Option \`${ARG}\` requires a name
-		echo
-		usage
-	fi
-
-	jq --tab ".servername=\"${SERVERNAME}\"" "${LOCALCONFIG}" > "${TMP}"
-	cp "${TMP}" "${LOCALCONFIG}"
 
 elif [ "${ARG}" = '-i' ] || [ "${ARG}" = '--install' ]; then
 

--- a/pzserver/pzst_config
+++ b/pzserver/pzst_config
@@ -6,7 +6,7 @@ TMP=$(mktemp)
 
 usage() {
 	rm -f "${TMP}"
-	echo "Usage ${0} [--add|--del|--admin <username>|--servername <name>|--install <path>|--port <port>]"
+	echo "Usage ${0} [--add|--del|--admin <username>|--install <path>|--port <port>]"
 	exit
 }
 

--- a/pzserver/pzstart
+++ b/pzserver/pzstart
@@ -8,7 +8,7 @@ check_not_running
 
 check_first_time
 
-detach flock -n "${PZSERVERLOCK}" "$(dirname "${0}")/pzstartloop" ${ADMINUSEROPTION} ${ADMINPASSWDOPTION} ${@} &
+detach flock -n "${PZSERVERLOCK}" "$(dirname "${0}")/pzstartloop" ${SERVERNAMEOPTION} ${ADMINUSEROPTION} ${ADMINPASSWDOPTION} ${@} &
 
 sleep 0.5
 


### PR DESCRIPTION
Instead of the server being hardcoded to "servertest" I changed it to be what user you have the server on.
This was to combat an issue I had where I wanted to use these tools for an already existing server that I named something else other than servertest.